### PR TITLE
Add more backgrounds and colors to elements, add font tweaks

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,10 @@
 const palette = {
 	background: '#2a2838',
 	background2: '#262433',
+	background3: '#363450',
+	background4: '#2b2a35',
+	background5: '#201D2B',
+	background6: '#1D1A27',
 	foreground: '#eeffff',
 	comments: '#eeffff88',
 
@@ -17,20 +21,54 @@ export const theme = {
 	type: "dark",
 	colors: {
 		"sideBar.background": palette.background2,
-		'statusBar.background': palette.background2,
-		'editorGroupHeader.tabsBackground': palette.background2,
+		'statusBar.background': palette.background5,
+		'editorGroupHeader.tabsBackground': palette.background5,
+		"editorPane.background": palette.background6,
+		"editorWidget.border": palette.background3,
+		"focusBorder": palette.background3,
+		"sideBar.border": palette.background3,
 
 		"activityBar.background": palette.background,
+		"activityBar.activeBackground": palette.background3,
+		"activityBar.activeBorder": palette.functions,
+
+		"button.background": palette.functions,
+		"button.foreground": "#212121",
+
+		"list.hoverBackground": palette.background3,
+		"list.focusBackground": palette.background3,
+		"list.activeSelectionBackground": palette.background3,
+		"list.inactiveSelectionBackground": palette.background4,
 
 		"editor.background": palette.background,
 		'editorHoverWidget.background': palette.background,
+		"editorSuggestWidget.background": palette.background6,
 
 		"editor.foreground": palette.foreground,
 		"editorLineNumber.foreground": '#eeffff44',
+		"editor.lineHighlightBorder": palette.background3,
+
+		"editorGutter.addedBackground": palette.strings + "de",
+		"editorGutter.modifiedBackground": palette.functions + "de",
+		"editorCutter.deletedBackground": palette.literals + "de",
+
+		"quickInput.background": palette.background5,
+
+		"input.background": palette.background6,
+		"input.border": palette.functions,
+
+		"dropdown.background": palette.background6,
+
+		'tab.inactiveBackground': palette.background2,
+		'tab.activeBorder': palette.functions,
+		'tab.hoverBackground': palette.background3,
+
+		"notifications.background": palette.background5,
 
 		"activityBarBadge.background": palette.functions,
-		'tab.inactiveBackground': palette.background2,
 		"sideBarTitle.foreground": "#bbbbbb",
+		"panel.background": palette.background5,
+		"terminal.background": palette.background6
 	},
 	tokenColors: [
 		{
@@ -54,7 +92,8 @@ export const theme = {
 				"punctuation.separator",
 			],
 			settings: {
-				foreground: palette.keywords
+				foreground: palette.keywords,
+				fontStyle: "bold"
 			}
 		},
 		{
@@ -64,6 +103,7 @@ export const theme = {
 				'variable.function',
 				'support.function',
 				'keyword.other.special-method',
+				"entity.name.section.python.renpy.label"
 			],
 			settings: {
 				foreground: palette.functions
@@ -76,6 +116,13 @@ export const theme = {
 			],
 			settings: {
 				foreground: palette.strings
+			}
+		},
+		{
+			name: "Strings (Ren'Py)",
+			scope: "string.quoted.double.single-line.python.renpy",
+			settings: {
+				fontStyle: "italic"
 			}
 		},
 		{
@@ -104,6 +151,15 @@ export const theme = {
 			],
 			settings: {
 				"foreground": palette.literals
+			}
+		},
+		{
+			name: "Placeholders",
+			scope: [
+				"constant.other.placeholder.tags"
+			],
+			settings: {
+				"foreground": palette.foreground
 			}
 		},
 		{

--- a/themes/Academy City-color-theme.json
+++ b/themes/Academy City-color-theme.json
@@ -3,16 +3,42 @@
   "type": "dark",
   "colors": {
     "sideBar.background": "#262433",
-    "statusBar.background": "#262433",
-    "editorGroupHeader.tabsBackground": "#262433",
+    "statusBar.background": "#201D2B",
+    "editorGroupHeader.tabsBackground": "#201D2B",
+    "editorPane.background": "#1D1A27",
+    "editorWidget.border": "#363450",
+    "focusBorder": "#363450",
+    "sideBar.border": "#363450",
     "activityBar.background": "#2a2838",
+    "activityBar.activeBackground": "#363450",
+    "activityBar.activeBorder": "#5ebae6",
+    "button.background": "#5ebae6",
+    "button.foreground": "#212121",
+    "list.hoverBackground": "#363450",
+    "list.focusBackground": "#363450",
+    "list.activeSelectionBackground": "#363450",
+    "list.inactiveSelectionBackground": "#2b2a35",
     "editor.background": "#2a2838",
     "editorHoverWidget.background": "#2a2838",
+    "editorSuggestWidget.background": "#1D1A27",
     "editor.foreground": "#eeffff",
     "editorLineNumber.foreground": "#eeffff44",
-    "activityBarBadge.background": "#5ebae6",
+    "editor.lineHighlightBorder": "#363450",
+    "editorGutter.addedBackground": "#1fdbacde",
+    "editorGutter.modifiedBackground": "#5ebae6de",
+    "editorCutter.deletedBackground": "#e02d60de",
+    "quickInput.background": "#201D2B",
+    "input.background": "#1D1A27",
+    "input.border": "#5ebae6",
+    "dropdown.background": "#1D1A27",
     "tab.inactiveBackground": "#262433",
-    "sideBarTitle.foreground": "#bbbbbb"
+    "tab.activeBorder": "#5ebae6",
+    "tab.hoverBackground": "#363450",
+    "notifications.background": "#201D2B",
+    "activityBarBadge.background": "#5ebae6",
+    "sideBarTitle.foreground": "#bbbbbb",
+    "panel.background": "#201D2B",
+    "terminal.background": "#1D1A27"
   },
   "tokenColors": [
     {
@@ -36,7 +62,8 @@
         "punctuation.separator"
       ],
       "settings": {
-        "foreground": "#7599e6"
+        "foreground": "#7599e6",
+        "fontStyle": "bold"
       }
     },
     {
@@ -45,7 +72,8 @@
         "entity.name.function",
         "variable.function",
         "support.function",
-        "keyword.other.special-method"
+        "keyword.other.special-method",
+        "entity.name.section.python.renpy.label"
       ],
       "settings": {
         "foreground": "#5ebae6"
@@ -58,6 +86,13 @@
       ],
       "settings": {
         "foreground": "#1fdbac"
+      }
+    },
+    {
+      "name": "Strings (Ren'Py)",
+      "scope": "string.quoted.double.single-line.python.renpy",
+      "settings": {
+        "fontStyle": "italic"
       }
     },
     {
@@ -86,6 +121,15 @@
       ],
       "settings": {
         "foreground": "#e02d60"
+      }
+    },
+    {
+      "name": "Placeholders",
+      "scope": [
+        "constant.other.placeholder.tags"
+      ],
+      "settings": {
+        "foreground": "#eeffff"
       }
     },
     {


### PR DESCRIPTION
This PR makes the following changes:

- Adds more background colors to elements such as the terminal, panel, Zen Mode pane, etc.
- Uses accent color (functions) in some tab borders.
- Adds italicized strings to Ren'Py files for easier readability
- Includes new settings for string interpolated variables
- Updates keyword rule to be bold font

## Screenshots

<img width="1552" alt="Screen Shot 2020-04-21 at 12 02 37" src="https://user-images.githubusercontent.com/13445064/79887623-30495980-83c9-11ea-8950-b8a2d44a8d25.png">

<img width="1552" alt="Screen Shot 2020-04-21 at 12 02 47" src="https://user-images.githubusercontent.com/13445064/79887658-3a6b5800-83c9-11ea-8694-ecf0e4a288d5.png">

<img width="620" alt="Screen Shot 2020-04-21 at 12 03 04" src="https://user-images.githubusercontent.com/13445064/79887665-3dfedf00-83c9-11ea-9ea7-01ac9def908b.png">

<img width="1105" alt="Screen Shot 2020-04-21 at 12 03 36" src="https://user-images.githubusercontent.com/13445064/79887674-41926600-83c9-11ea-86f5-21f25949acda.png">

![Screen Shot 2020-04-21 at 12 03 42](https://user-images.githubusercontent.com/13445064/79887754-62f35200-83c9-11ea-97d0-7a8c4d9a4f9d.png)
